### PR TITLE
Update config name and descriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-ably",
+	"name": "vscode-ably",
 	"displayName": "Ably for VSCode",
 	"description": "Manage Ably apps from VSCode",
 	"version": "0.0.1",
@@ -10,7 +10,7 @@
 		"Other"
 	],
 	"activationEvents": [
-        "onCommand:vscode-ably.helloWorld"
+		"onCommand:vscode-ably.helloWorld"
 	],
 	"main": "./dist/extension.js",
 	"contributes": {
@@ -23,16 +23,16 @@
 		"configuration": {
 			"title": "Ably",
 			"properties": {
-			  "ably.accountId": {
-				"type": "string",
-				"default": null,
-				"description": "Your Ably Account ID."
-			  },
-			  "ably.controlApiKey": {
-				"type": "string",
-				"default": null,
-				"description": "The Ably Control Key with read & write capabilities for Apps & Keys. "
-			  }
+				"ably.accountId": {
+					"type": "string",
+					"default": null,
+					"markdownDescription": "Your [Ably Account ID](https://ably.com/documentation/control-api#account-id)."
+				},
+				"ably.accessToken": {
+					"type": "string",
+					"default": null,
+					"markdownDescription": "Your [Ably access token](https://ably.com/documentation/control-api#creating-access-token). You will need read and write capabilities for all features."
+				}
 			}
 		}
 	},


### PR DESCRIPTION
This PR updates the configuration property descriptions with links to resources on finding your account ID and access token as well as renaming `controlApiKey` to `accessToken` to make it easier to understand in the context of the Ably dashboard.