### PR TITLE
Fix conversion of string to boolean in Create App

### DIFF
--- a/src/command/CreateApp.ts
+++ b/src/command/CreateApp.ts
@@ -104,7 +104,7 @@ export async function createAblyApp(context: ExtensionContext, controlApi: AblyC
 	const createAppContext: CreateAppContext = {
 		appName: state.appName,
 		appState: state.appState,
-		tlsOnly: Boolean(state.tlsOnly),
+		tlsOnly: state.tlsOnly === 'true',
 		apnsUseSandboxEndpoint: false,
 	};
 	await controlApi.createApp(createAppContext);


### PR DESCRIPTION
Casting with Boolean() seemed to only do a check for non-null rather than consideration for string being 'true' or 'false'.

This replaces this check with an === instead for the string 'true'.