### PR TITLE
Fix refresh functionality

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,7 @@ export function activate(context: vscode.ExtensionContext) {
 	const ablyAppProvider = new AblyAppProvider(config, ablyControlApi, telemetryProvider);
 	vscode.window.registerTreeDataProvider('ablyAppExplorer', ablyAppProvider);
 	vscode.commands.registerCommand("ably.copyToClipboard", ablyAppProvider.handleCopy);
-	vscode.commands.registerCommand("ably.refresh", ablyAppProvider.refresh);
+	vscode.commands.registerCommand("ably.refresh", () => { ablyAppProvider.refresh(); });
 	let disposable = vscode.commands.registerCommand('ably.createApp', () => {
 		createAblyApp(context, ablyControlApi, telemetryProvider)
 			.catch(console.error);


### PR DESCRIPTION
The state of ablyAppProvider was not being correctly maintained, resulting in the refresh functionality not working.

This is a simple fix by wrapping it in a function, ensuring we keep the object the same.