### PR TITLE
Add refresh after app creation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,8 @@ export function activate(context: vscode.ExtensionContext) {
 	vscode.commands.registerCommand("ably.refresh", ablyAppProvider.refresh);
 	let disposable = vscode.commands.registerCommand('ably.createApp', () => {
 		createAblyApp(context, ablyControlApi, telemetryProvider)
-			.catch(console.error);
+			.catch(console.error)
+			.then(() => { ablyAppProvider.refresh(); });
 	});
 
 	context.subscriptions.push(disposable);


### PR DESCRIPTION
So the app will appear in the sidebar after app creation, this adds a refresh should an app be correctly created.